### PR TITLE
Implement as_bytes for signature, signing key and verification key

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -46,9 +46,16 @@ impl TryFrom<&[u8]> for Signature {
 
 impl From<Signature> for [u8; 64] {
     fn from(sig: Signature) -> [u8; 64] {
+        sig.as_bytes()
+    }
+}
+
+impl Signature {
+    /// Returns `R` as `S` signature part in contiguous array
+    pub fn as_bytes(&self) -> [u8; 64] {
         let mut bytes = [0; 64];
-        bytes[0..32].copy_from_slice(&sig.R_bytes[..]);
-        bytes[32..64].copy_from_slice(&sig.s_bytes[..]);
+        bytes[0..32].copy_from_slice(&self.R_bytes[..]);
+        bytes[32..64].copy_from_slice(&self.s_bytes[..]);
         bytes
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -46,13 +46,15 @@ impl TryFrom<&[u8]> for Signature {
 
 impl From<Signature> for [u8; 64] {
     fn from(sig: Signature) -> [u8; 64] {
-        sig.as_bytes()
+        sig.to_bytes()
     }
 }
 
 impl Signature {
-    /// Returns `R` as `S` signature part in contiguous array
-    pub fn as_bytes(&self) -> [u8; 64] {
+    /// Returns the bytes of the signature.
+    ///
+    /// This is the same as `.into()`, but does not require type inference.
+    pub fn to_bytes(&self) -> [u8; 64] {
         let mut bytes = [0; 64];
         bytes[0..32].copy_from_slice(&self.R_bytes[..]);
         bytes[32..64].copy_from_slice(&self.s_bytes[..]);

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -21,9 +21,16 @@ pub struct SigningKey {
 }
 
 impl SigningKey {
-    /// Returns seed part of signing key
-    pub fn as_bytes(&self) -> [u8; 32] {
+    /// Returns the byte encoding of the signing key.
+    ///
+    /// This is the same as `.into()`, but does not require type inference.
+    pub fn to_bytes(&self) -> [u8; 32] {
         self.seed
+    }
+
+    /// View the byte encoding of the signing key.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.seed
     }
 }
 

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -20,6 +20,13 @@ pub struct SigningKey {
     vk: VerificationKey,
 }
 
+impl SigningKey {
+    /// Returns seed part of signing key
+    pub fn as_bytes(&self) -> [u8; 32] {
+        self.seed
+    }
+}
+
 impl core::fmt::Debug for SigningKey {
     fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
         fmt.debug_struct("SigningKey")

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -34,9 +34,16 @@ use crate::{Error, Signature};
 pub struct VerificationKeyBytes(pub(crate) [u8; 32]);
 
 impl VerificationKeyBytes {
-    /// Returns `VerificationKey` serialized in bytes
-    pub fn as_bytes(&self) -> [u8; 32] {
+    /// Returns the byte encoding of the verification key.
+    ///
+    /// This is the same as `.into()`, but does not require type inference.
+    pub fn to_bytes(&self) -> [u8; 32] {
         self.0
+    }
+
+    /// View the byte encoding of the verification key.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
     }
 }
 

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -96,7 +96,7 @@ impl From<VerificationKeyBytes> for [u8; 32] {
 ///   Curve25519, and non-canonical encodings MUST be accepted;
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#concreteed25519
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "VerificationKeyBytes"))]
 #[cfg_attr(feature = "serde", serde(into = "VerificationKeyBytes"))]

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -33,6 +33,13 @@ use crate::{Error, Signature};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerificationKeyBytes(pub(crate) [u8; 32]);
 
+impl VerificationKeyBytes {
+    /// Returns `VerificationKey` serialized in bytes
+    pub fn as_bytes(&self) -> [u8; 32] {
+        self.0
+    }
+}
+
 impl core::fmt::Debug for VerificationKeyBytes {
     fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
         fmt.debug_tuple("VerificationKeyBytes")


### PR DESCRIPTION
Using `try_into|into` is not very convenient