### PR TITLE
Add SigningKey::verification_key convenience method

### DIFF
--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -32,6 +32,11 @@ impl SigningKey {
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.seed
     }
+
+    /// Obtain the verification key associated with this signing key.
+    pub fn verification_key(&self) -> VerificationKey {
+        self.vk
+    }
 }
 
 impl core::fmt::Debug for SigningKey {

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -163,6 +163,18 @@ impl TryFrom<[u8; 32]> for VerificationKey {
 }
 
 impl VerificationKey {
+    /// Returns the byte encoding of the verification key.
+    ///
+    /// This is the same as `.into()`, but does not require type inference.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.A_bytes.0
+    }
+
+    /// View the byte encoding of the verification key.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.A_bytes.0
+    }
+
     /// Verify a purported `signature` on the given `msg`.
     ///
     /// ## Consensus properties


### PR DESCRIPTION
This is slightly easier than calling `VerificationKey::from(&sk)`.