### PR TITLE
Remove Copy implementation from SigningKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Entries are listed in reverse chronological order.
 
+# 2.0.0
+
+* Remove `Copy` implementation from `SigningKey`.
+
 # 1.2.0
 
 * Add `to_bytes`/`as_bytes` for `VerificationKey`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ed25519-consensus"
 # Before publishing:
 # - update CHANGELOG.md
 # - update html_root_url
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/ed25519-consensus/1.2.0")]
+#![doc(html_root_url = "https://docs.rs/ed25519-consensus/2.0.0")]
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -9,7 +9,7 @@ use crate::{Error, Signature, VerificationKey, VerificationKeyBytes};
 /// An Ed25519 signing key.
 ///
 /// This is also called a secret key by other implementations.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "SerdeHelper"))]
 #[cfg_attr(feature = "serde", serde(into = "SerdeHelper"))]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -14,7 +14,7 @@ fn parsing() {
     // Most of these types don't implement Eq, so we check a round trip
     // conversion to bytes, using these as the reference points:
 
-    let sk_array: [u8; 32] = sk.into();
+    let sk_array: [u8; 32] = sk.clone().into();
     let pk_array: [u8; 32] = pk.into();
     let pkb_array: [u8; 32] = pkb.into();
     let sig_array: [u8; 64] = sig.into();


### PR DESCRIPTION
Removes `Copy` implementation from `SigningKey` in favor of requiring explicit use of `Clone`, related to comments from https://github.com/informalsystems/tendermint-rs/issues/1077