### PR TITLE
Expanded secret key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.9", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["u64_backend", "alloc"] }
-serde = { version = "1", default-features = false, features = ["derive"] }
+serde = { version = "1", optional = true, features = ["derive"] }
 zeroize = { version = "1.1", default-features = false }
 thiserror = { version = "1", optional = true }
 
@@ -30,7 +30,7 @@ once_cell = "1.4"
 
 [features]
 std = ["thiserror"]
-default = ["std"]
+default = ["serde", "std"]
 
 [[test]]
 name = "rfc8032"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.9", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["u64_backend", "alloc"] }
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
 zeroize = { version = "1.1", default-features = false }
 thiserror = { version = "1", optional = true }
 
@@ -30,7 +30,7 @@ once_cell = "1.4"
 
 [features]
 std = ["thiserror"]
-default = ["serde", "std"]
+default = ["std"]
 
 [[test]]
 name = "rfc8032"

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -1,5 +1,5 @@
 use core::convert::TryFrom;
-use std::fmt::Formatter;
+use core::fmt::Formatter;
 
 use curve25519_dalek::{constants, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for SigningKey {
         impl<'de> Visitor<'de> for TupleVisitor {
             type Value = SigningKey;
 
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
                 formatter.write_str("an Ed25519 seed key or expanded secret key")
             }
 

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -1,5 +1,5 @@
 use core::convert::TryFrom;
-use core::fmt::Formatter;
+use std::fmt::Formatter;
 
 use curve25519_dalek::{constants, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for SigningKey {
         impl<'de> Visitor<'de> for TupleVisitor {
             type Value = SigningKey;
 
-            fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("an Ed25519 seed key or expanded secret key")
             }
 

--- a/tests/rfc8032.rs
+++ b/tests/rfc8032.rs
@@ -7,9 +7,19 @@
 use bincode;
 use ed25519_consensus::*;
 use hex;
+use sha2::{Digest, Sha512};
+use std::convert::TryInto;
 
 fn rfc8032_test_case(sk_bytes: Vec<u8>, pk_bytes: Vec<u8>, sig_bytes: Vec<u8>, msg: Vec<u8>) {
-    let sk: SigningKey = bincode::deserialize(&sk_bytes).expect("sk should deserialize");
+    let sk: SigningKey;
+    if sk_bytes.len() == 32 {
+        let sk_bytes: [u8; 32] = sk_bytes.as_slice().try_into().unwrap();
+        sk = SigningKey::from(sk_bytes);
+    } else if sk_bytes.len() == 64 {
+        sk = bincode::deserialize(&sk_bytes).expect("sk should deserialize");
+    } else {
+        panic!("invalid sk_bytes length");
+    }
     let pk: VerificationKey = bincode::deserialize(&pk_bytes).expect("pk should deserialize");
     let sig: Signature = bincode::deserialize(&sig_bytes).expect("sig should deserialize");
 
@@ -62,6 +72,48 @@ fn rfc8032_test_3() {
     rfc8032_test_case(
         hex::decode("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7")
             .expect("hex should decode"),
+        hex::decode("fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025")
+            .expect("hex should decode"),
+        hex::decode("6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a")
+            .expect("hex should decode"),
+        hex::decode("af82")
+            .expect("hex should decode"),
+    );
+}
+
+#[test]
+fn rfc8032_test_1_expanded() {
+    rfc8032_test_case(
+        Sha512::digest(hex::decode("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")
+            .expect("hex should decode").as_slice()).to_vec(),
+        hex::decode("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
+            .expect("hex should decode"),
+        hex::decode("e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b")
+            .expect("hex should decode"),
+        hex::decode("")
+            .expect("hex should decode"),
+    );
+}
+
+#[test]
+fn rfc8032_test_2_expanded() {
+    rfc8032_test_case(
+        Sha512::digest(hex::decode("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb")
+            .expect("hex should decode").as_slice()).to_vec(),
+        hex::decode("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c")
+            .expect("hex should decode"),
+        hex::decode("92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00")
+            .expect("hex should decode"),
+        hex::decode("72")
+            .expect("hex should decode"),
+    );
+}
+
+#[test]
+fn rfc8032_test_3_expanded() {
+    rfc8032_test_case(
+        Sha512::digest(hex::decode("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7")
+            .expect("hex should decode").as_slice()).to_vec(),
         hex::decode("fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025")
             .expect("hex should decode"),
         hex::decode("6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a")

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -14,27 +14,27 @@ fn parsing() {
     // Most of these types don't implement Eq, so we check a round trip
     // conversion to bytes, using these as the reference points:
 
-    let sk_array: [u8; 32] = sk.clone().into();
+    let sk_array: [u8; 64] = sk.clone().into();
     let pk_array: [u8; 32] = pk.into();
     let pkb_array: [u8; 32] = pkb.into();
     let sig_array: [u8; 64] = sig.into();
 
-    let sk2 = SigningKey::try_from(sk.as_ref()).unwrap();
+    let sk2 = SigningKey::try_from(sk.clone()).unwrap();
     let pk2 = VerificationKey::try_from(pk.as_ref()).unwrap();
     let pkb2 = VerificationKeyBytes::try_from(pkb.as_ref()).unwrap();
     let sig2 = Signature::try_from(<[u8; 64]>::from(sig).as_ref()).unwrap();
 
-    assert_eq!(&sk_array[..], sk2.as_ref());
+    assert_eq!(sk_array, Into::<[u8; 64]>::into(sk2));
     assert_eq!(&pk_array[..], pk2.as_ref());
     assert_eq!(&pkb_array[..], pkb2.as_ref());
     assert_eq!(&sig_array[..], <[u8; 64]>::from(sig2).as_ref());
 
-    let sk3: SigningKey = bincode::deserialize(sk.as_ref()).unwrap();
+    let sk3: SigningKey = bincode::deserialize(Into::<[u8; 64]>::into(sk).as_ref()).unwrap();
     let pk3: VerificationKey = bincode::deserialize(pk.as_ref()).unwrap();
     let pkb3: VerificationKeyBytes = bincode::deserialize(pkb.as_ref()).unwrap();
     let sig3: Signature = bincode::deserialize(<[u8; 64]>::from(sig).as_ref()).unwrap();
 
-    assert_eq!(&sk_array[..], sk3.as_ref());
+    assert_eq!(sk_array, Into::<[u8; 64]>::into(sk3));
     assert_eq!(&pk_array[..], pk3.as_ref());
     assert_eq!(&pkb_array[..], pkb3.as_ref());
     assert_eq!(&sig_array[..], <[u8; 64]>::from(sig3).as_ref());


### PR DESCRIPTION
Initial stab at the expanded secret key feature. This is an extreme solution where the seed key is always hashed into an expanded secret key. The seed key is not stored, so it is straightforward when we want to serialize/deserialize.

If we kept the seed key, we would need to decide how we deserialize bytes into a SigningKey, because the
serialization does not keep the key size. So, deserialization has to know it upfront. (The expanded secret key is 64 bytes.) I had half an implementation for that, too, but there are so many assumptions that I want to confirm with you if keeping the seed key is crucial for you.

Furthermore, I had to rewrite the SerdeHelper into regular serialization/deserialization, because Serde can not automatically serialize byte arrays bigger than 32 bytes. While reviewing the PR, I noticed that this required the std::fmt library. I'm unfamiliar with no_std, but if this violates that paradigm, I'll keep working on it. I'd appreciate your advice there.

The tests will immediately show the difference. The unit tests show that the SigningKey is a 64-byte key, and the RFC tests show that the original seed keys can also be used to create a SigningKey.
